### PR TITLE
integrate into .zprezto

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ Here's example bindings for Emacs users:
     bindkey '^X^R' view-file-at-point
     bindkey '^[!' run-shell-word-at-point
 
+##### integrate into `.zprezto` project
+
+    > git clone --depth=1 <current_project> ~/.zprezto/modules
+    > add to ~/.zpreztorc
+
+```zsh
+zstyle ':prezto:load' pmodule
+    ....
+    'zsh-shell-word-at-point'`
+```
+
+
 License
 -------
 

--- a/init.zsh
+++ b/init.zsh
@@ -1,0 +1,9 @@
+
+### init
+source "${0:h}/shell-word-at-point"
+
+autoload -Uz shell-word-at-point
+
+bindkey '^X^F' edit-file-at-point
+bindkey '^X^R' view-file-at-point
+bindkey '^[!' run-shell-word-at-point


### PR DESCRIPTION

thinks for @knu wrote this good project, and I am using  [prezto](https://github.com/sorin-ionescu/prezto.git) prelude to my zsh configration.

so  I integrate into `zsh-shell-word-at-point` to  `prezto` .

thinks again.
